### PR TITLE
Update cnmf.py

### DIFF
--- a/src/mosaicmpi/cnmf.py
+++ b/src/mosaicmpi/cnmf.py
@@ -705,14 +705,11 @@ class cNMF():
                 iter_result = self.paths['iter_spectra'] % (row['n_components'], row['iter'])
                 if not os.path.exists(iter_result) or os.path.getsize(iter_result) == 0:
                     failed.append(iter_result)
-            if failed:
-                raise ValueError(
-                    f"{(len(failed))} files from the factorization step are missing or empty:\n  - " + 
-                    "\n  - ".join(failed)
-                )
             if failed and not skip_missing_iterations:
                 raise ValueError(
-                    f"Postprocessing could not proceed. To skip missing iterations, use --skip_missing_iterations."
+                    f"Postprocessing could not proceed. To skip missing iterations, use --skip_missing_iterations." + 
+                    f"\n {(len(failed))} files from the factorization step are missing or empty:\n  - " + 
+                    "\n  - ".join(failed)
                 )
             elif failed and skip_missing_iterations:
                 logging.warning("Missing files will be skipped")


### PR DESCRIPTION
Fixed a `Raise ValueError` preventing the postprocess code from continuing further if `--skip_missing_iterations` already enabled.

The code will now only raise the ValueError if the post process has failed and the `--skip_missing_iterations` flag was not enabled.