### PR TITLE
Fix for the undefined 'gene_stats' name error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # mosaicMPI: Mosaic Multi-resolution Program Integration
 
-![version badge](https://img.shields.io/badge/version-2.5.3-blue)
+![version badge](https://img.shields.io/badge/version-2.5.4-blue)
 [![PyPI Latest Release](https://img.shields.io/pypi/v/mosaicmpi.svg)](https://pypi.org/project/mosaicmpi/)
 [![Conda Latest Release](https://img.shields.io/conda/vn/conda-forge/mosaicmpi)](https://anaconda.org/conda-forge/mosaicmpi/)
 [![Documentation status](https://readthedocs.org/projects/mosaicmpi/badge/?version=latest&style=flat)](https://mosaicmpi.readthedocs.io)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mosaicmpi
-version = 2.5.3
+version = 2.5.4
 author = Ted Verhey
 author_email = tbverhey@ucalgary.ca
 description = mosaicMPI: Mosaic Multi-resolution Program Integration

--- a/src/mosaicmpi/cli.py
+++ b/src/mosaicmpi/cli.py
@@ -373,6 +373,7 @@ def cmd_set_parameters(name, output_dir, odg_method, odg_param, min_mean, k_rang
     utils.save_fig(fig, os.path.join(output_dir, name, "feature_meanvar"), formats=("pdf", "png"), target_dpi=400, facecolor='white')
 
     # output table with gene overdispersion measures
+    gene_stats = dataset.adata.var
     gene_stats.to_csv(os.path.join(output_dir, name, "feature_stats.tsv"), sep="\t")
     
     # process k-value selection inputs


### PR DESCRIPTION
When running mosaicmpi set-parameters through the CLI, the code throws an error as gene_stats was not defined. 

This error was introduced in v2.5.3, where references to `dataset.adata.var` were changed to `gene_stats`. Although `gene_stats` was defined to be `dataset.adata.var` in the `cmd_model_odg` function, this definition was absent in the `cmd_set_parameters` function. 