### PR TITLE
Update setup.cfg with a maximum SciPy version to prevent pyGAM from throwing an error during mosaicmpi select-hvf custom

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     pyyaml
     requests
     scikit-learn
-    scipy
+    scipy <= 1.13.1
     seaborn
     statsmodels
     tomli

--- a/src/mosaicmpi/plots.py
+++ b/src/mosaicmpi/plots.py
@@ -620,7 +620,7 @@ def plot_stratified_hvf_upset(dataset: Dataset, figsize: Collection = (6, 4), sh
         stratified_lists[stratum] = df_strat.index[df_strat["selected"]].to_list()
     fig = Figure(figsize=figsize)
     upsetplot.UpSet(upsetplot.from_contents(stratified_lists), show_counts=show_counts).plot(fig=fig)
-    fig.suptitle(f"HVF features stratified by: {dataset.adata.uns["hvf"]["stratify_by"]}")
+    fig.suptitle(f"HVF features stratified by: {dataset.adata.uns['hvf']['stratify_by']}")
     return fig
 
 def plot_features_upset(integration: Integration, figsize=[6, 4], show_counts: bool = False):


### PR DESCRIPTION
**Updated setup.cfg file to indicate the newest version of SciPy allowed, which will resolve a potential error that occurs in modelling OD genes when using pyGAM with any version of SciPy >= 1.14.0.**

I ran into the following error when running `mosaicmpi select-hvf custom`. The error can be traced back to the pyGAM package that is being used to compute the OD genes on line 822 of `mosaicMPI/src/dataset.py`. This error seems to stem from an update to the SciPy package, where `.A` was previously used to convert the data type from a matrix to an array, but has been depreciated since SciPy v1.14.0. However, pyGAM still utilizes the `.A` notation, which then leads to the error shown below. As such, when using pyGAM only SciPy version equal to or less than v1.13.1 are still supported. The `setup.cfg` file has been changed to prevent this error.

```2025-01-16 23:44:23,650 [INFO] mosaicMPI version 2.7.3
2025-01-16 23:44:23,650 [INFO] /home/gurveer.gill1/software/miniconda3/envs/mosaic/bin/mosaicmpi select-hvf custom --name cNMF_5_100_5 --input dataset_vishd_filtered.h5ad --feature_list solid_013_exclusi
on_OD_genes_list_024um.txt
Traceback (most recent call last):
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/bin/mosaicmpi", line 10, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/mosaicmpi/cli.py", line 369, in cmd_select_hvf_custom
    dataset.select_hvf(feature_list = feature_list)
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/mosaicmpi/dataset.py", line 822, in select_hvf
    model = pygam.LinearGAM(pygam.s(0, n_splines=n_splines, spline_order=spline_order)).fit(X=df_model["log_mean"], y=df_model["log_variance"])
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/pygam/pygam.py", line 913, in fit
    self._pirls(X, y, weights)
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/pygam/pygam.py", line 751, in _pirls
    E = self._cholesky(S + P, sparse=False, verbose=self.verbose)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/pygam/pygam.py", line 518, in _cholesky
    L = cholesky(A, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^
  File "/home/gurveer.gill1/software/miniconda3/envs/mosaic/lib/python3.12/site-packages/pygam/utils.py", line 81, in cholesky
    A = A.A
        ^^^
AttributeError: 'csr_matrix' object has no attribute 'A'```
